### PR TITLE
Cross-World Alliance

### DIFF
--- a/ReadyCheckHelper.sln
+++ b/ReadyCheckHelper.sln
@@ -7,14 +7,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadyCheckHelper", "ReadyCh
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|x64.ActiveCfg = Debug|x64
+		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|x64.Build.0 = Debug|x64
+		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Release|x64.ActiveCfg = Release|x64
+		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ReadyCheckHelper/MemoryHandler.cs
+++ b/ReadyCheckHelper/MemoryHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Dalamud.Hooking;
 using FFXIVClientStructs.FFXIV.Client.Game.Group;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
@@ -102,7 +102,7 @@ public unsafe class MemoryHandler
             else if( groupIndex < infoProxyCrossRealm->LocalPlayerGroupIndex )
                      groupIndex += 1;
 
-            return new PartyListLayoutResult( !infoProxyCrossRealm->IsInAllianceRaid, groupIndex, pGroupMember->MemberIndex);
+            return new PartyListLayoutResult( true, groupIndex, pGroupMember->MemberIndex);
         }
 
         return null;

--- a/ReadyCheckHelper/MemoryHandler.cs
+++ b/ReadyCheckHelper/MemoryHandler.cs
@@ -94,7 +94,15 @@ public unsafe class MemoryHandler
             var pGroupMember = InfoProxyCrossRealm.GetMemberByContentId(contentId);
             if (pGroupMember == null || contentId == 0)
                 return null;
-            return new PartyListLayoutResult(infoProxyCrossRealm->IsCrossRealm && !infoProxyCrossRealm->IsInAllianceRaid, pGroupMember->GroupIndex, pGroupMember->MemberIndex);
+
+            //  In order to match how this plugin indexes in the UI, for cross-world alliances, we need
+            //  to make the player's group be 0, and shift any groups before the player's group by one.
+            var groupIndex = pGroupMember->GroupIndex;
+            if( groupIndex == infoProxyCrossRealm->LocalPlayerGroupIndex ) groupIndex = 0;
+            else if( groupIndex < infoProxyCrossRealm->LocalPlayerGroupIndex )
+                     groupIndex += 1;
+
+            return new PartyListLayoutResult( !infoProxyCrossRealm->IsInAllianceRaid, groupIndex, pGroupMember->MemberIndex);
         }
 
         return null;
@@ -106,11 +114,11 @@ public struct PartyListLayoutResult
     public PartyListLayoutResult(bool crossWorld, int groupNumber, int partyMemberIndex)
     {
         CrossWorld = crossWorld;
-        GroupNumber = groupNumber;
+        GroupIndex = groupNumber;
         PartyMemberIndex = partyMemberIndex;
     }
 
     public readonly bool CrossWorld;
-    public readonly int GroupNumber;
+    public readonly int GroupIndex;
     public readonly int PartyMemberIndex;
 }

--- a/ReadyCheckHelper/MemoryHandler.cs
+++ b/ReadyCheckHelper/MemoryHandler.cs
@@ -70,8 +70,9 @@ public unsafe class MemoryHandler
             return null;
 
         //	We're only in a crossworld party if the cross realm proxy says we are; however, it can say we're cross-realm when
-        //	we're in a regular party if we entered an instance as a cross-world party, so account for that too.
-        if (groupManager->MainGroup.MemberCount > 0)
+        //	we're in a regular party if we entered an instance as a cross-world party, so account for that too.  The GroupManager
+        //  check for an alliance covers situations where you are the only player left in your alliance, but still in the raid.
+        if (groupManager->MainGroup.MemberCount > 0 || groupManager->MainGroup.IsAlliance)
         {
             for (var i = 0; i < 8; ++i)
             {

--- a/ReadyCheckHelper/Plugin.cs
+++ b/ReadyCheckHelper/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
@@ -298,7 +298,7 @@ namespace ReadyCheckHelper
 
             //	We're only in a crossworld party if the cross realm proxy says we are; however, it can say we're cross-realm when
             //	we're in a regular party if we entered an instance as a cross-world party, so account for that too.
-            if (infoProxy->IsCrossRealm && !infoProxy->IsInAllianceRaid && groupManager->MainGroup.MemberCount < 1)
+            if (infoProxy->IsCrossRealm && groupManager->MainGroup.MemberCount < 1)
                 ProcessReadyCheckResults_CrossWorld();
             else
                 ProcessReadyCheckResults_Regular();

--- a/ReadyCheckHelper/Plugin.cs
+++ b/ReadyCheckHelper/Plugin.cs
@@ -297,8 +297,9 @@ namespace ReadyCheckHelper
                 return;
 
             //	We're only in a crossworld party if the cross realm proxy says we are; however, it can say we're cross-realm when
-            //	we're in a regular party if we entered an instance as a cross-world party, so account for that too.
-            if (infoProxy->IsCrossRealm && groupManager->MainGroup.MemberCount < 1)
+            //	we're in a regular party if we entered an instance as a cross-world party, so account for that too.  The GroupManager
+            //  check for an alliance covers situations where you are the only player left in your alliance, but still in the raid.
+            if (infoProxy->IsCrossRealm && !groupManager->MainGroup.IsAlliance && groupManager->MainGroup.MemberCount < 1)
                 ProcessReadyCheckResults_CrossWorld();
             else
                 ProcessReadyCheckResults_Regular();

--- a/ReadyCheckHelper/Resources/Language.Designer.cs
+++ b/ReadyCheckHelper/Resources/Language.Designer.cs
@@ -168,6 +168,24 @@ namespace ReadyCheckHelper.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Alliance List Icon Offset (Cross-World).
+        /// </summary>
+        internal static string ConfigOptionCrossWorldAllianceListIconOffset {
+            get {
+                return ResourceManager.GetString("ConfigOptionCrossWorldAllianceListIconOffset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alliance List Icon Scale (Cross-World).
+        /// </summary>
+        internal static string ConfigOptionCrossWorldAllianceListIconScale {
+            get {
+                return ResourceManager.GetString("ConfigOptionCrossWorldAllianceListIconScale", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Draw ready check on party/alliance lists..
         /// </summary>
         internal static string ConfigOptionDrawonPartyAllianceLists {

--- a/ReadyCheckHelper/Resources/Language.resx
+++ b/ReadyCheckHelper/Resources/Language.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <root>
     <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
@@ -84,8 +84,14 @@
     <data name="ConfigOptionAllianceListIconOffset" xml:space="preserve">
         <value>Alliance List Icon Offset</value>
     </data>
+    <data name="ConfigOptionCrossWorldAllianceListIconOffset" xml:space="preserve">
+        <value>Alliance List Icon Offset (Cross-World)</value>
+    </data>
     <data name="ConfigOptionAllianceListIconScale" xml:space="preserve">
         <value>Alliance List Icon Scale</value>
+    </data>
+    <data name="ConfigOptionCrossWorldAllianceListIconScale" xml:space="preserve">
+        <value>Alliance List Icon Scale (Cross-World)</value>
     </data>
     <data name="ButtonSaveandClose" xml:space="preserve">
         <value>Save and Close</value>

--- a/ReadyCheckHelper/Windows/ConfigWindow.cs
+++ b/ReadyCheckHelper/Windows/ConfigWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Text;
 using Dalamud.Interface.Utility;
@@ -78,6 +78,8 @@ public class ConfigWindow : Window, IDisposable
             ImGui.DragFloat($"{Language.ConfigOptionPartyListIconScale}###PartyListIconScale", ref Plugin.Configuration.mPartyListIconScale, 0.1f, 0.3f, 5.0f, "%f", ImGuiSliderFlags.AlwaysClamp);
             ImGui.DragFloat2($"{Language.ConfigOptionAllianceListIconOffset}###AllianceListIconOffset", ref Plugin.Configuration.mAllianceListIconOffset, 1f, -100f, 100f);
             ImGui.DragFloat($"{Language.ConfigOptionAllianceListIconScale}###AllianceListIconScale", ref Plugin.Configuration.mAllianceListIconScale, 0.1f, 0.3f, 5.0f, "%f", ImGuiSliderFlags.AlwaysClamp);
+            ImGui.DragFloat2($"{Language.ConfigOptionCrossWorldAllianceListIconOffset}###CrossWorldAllianceListIconOffset", ref Plugin.Configuration.mCrossWorldAllianceListIconOffset, 1f, -100f, 100f);
+            ImGui.DragFloat($"{Language.ConfigOptionCrossWorldAllianceListIconScale}###CrossWorldAllianceListIconScale", ref Plugin.Configuration.mCrossWorldAllianceListIconScale, 0.1f, 0.3f, 5.0f, "%f", ImGuiSliderFlags.AlwaysClamp);
         }
 
         ImGuiHelpers.ScaledDummy(5.0f);

--- a/ReadyCheckHelper/Windows/DebugWindow.cs
+++ b/ReadyCheckHelper/Windows/DebugWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -77,6 +77,7 @@ public class DebugWindow : Window, IDisposable
         var crossWorldGroupCount = infoproxy->GroupCount;
         ImGui.Text($"Number of Cross-World Groups: {crossWorldGroupCount}");
         ImGui.Text( $"Current Cross-World Group Index: {infoproxy->LocalPlayerGroupIndex}" );
+        ImGui.Text( $"InfoProxy Alliance: {infoproxy->IsInAllianceRaid}" );
         for (var i = 0; i < crossWorldGroupCount; ++i)
             ImGui.Text($"Number of Party Members (Group {i}): {InfoProxyCrossRealm.GetGroupMemberCount(i)}");
 
@@ -107,6 +108,7 @@ public class DebugWindow : Window, IDisposable
         ImGui.NextColumn();
 
         ImGui.Text("Party Data:");
+        ImGui.Text( $"GroupManager MainGroup Count: {groupManager->MainGroup.MemberCount}" );
         for (var i = 0; i < 8; ++i)
         {
             var pGroupMember = groupManager->MainGroup.GetPartyMemberByIndex(i);

--- a/ReadyCheckHelper/Windows/DebugWindow.cs
+++ b/ReadyCheckHelper/Windows/DebugWindow.cs
@@ -23,7 +23,6 @@ public class DebugWindow : Window, IDisposable
     private readonly Dictionary<uint, string> JobDict = new();
 
     public bool DrawPlaceholderData;
-    private bool AllowCrossWorldAllianceDrawing;
     private int NumNamesToTestChatMessage = 5;
 
     public DebugWindow(Plugin plugin) : base($"{Language.WindowTitleReadyCheckandAllianceDebugData}###Ready Check and Alliance Debug Data")
@@ -77,6 +76,7 @@ public class DebugWindow : Window, IDisposable
 
         var crossWorldGroupCount = infoproxy->GroupCount;
         ImGui.Text($"Number of Cross-World Groups: {crossWorldGroupCount}");
+        ImGui.Text( $"Current Cross-World Group Index: {infoproxy->LocalPlayerGroupIndex}" );
         for (var i = 0; i < crossWorldGroupCount; ++i)
             ImGui.Text($"Number of Party Members (Group {i}): {InfoProxyCrossRealm.GetGroupMemberCount(i)}");
 
@@ -89,7 +89,6 @@ public class DebugWindow : Window, IDisposable
             Plugin.ProcessedWindow.IsOpen = isOpen;
 
         ImGui.Checkbox("Debug Drawing on Party List", ref DrawPlaceholderData);
-        ImGui.Checkbox("Allow Cross-world Alliance List Drawing", ref AllowCrossWorldAllianceDrawing);
 
         if (ImGui.Button("Test Chat Message"))
             Plugin.ListUnreadyPlayersInChat([..LocalizationHelpers.TestNames.Take(NumNamesToTestChatMessage)]);
@@ -99,8 +98,11 @@ public class DebugWindow : Window, IDisposable
         ImGui.NextColumn();
         ImGui.Text("Ready Check Data:");
         var readyCheckdata = AgentReadyCheck.Instance()->ReadyCheckEntries;
-        for (var i = 0; i < readyCheckdata.Length; ++i)
-            ImGui.Text($"ID: {readyCheckdata[i].ContentId:X16}, State: {readyCheckdata[i].Status}");
+        for( var i = 0; i < readyCheckdata.Length; ++i )
+        {
+            var hudIndices = Plugin.MemoryHandler.GetHUDIndicesForChar( readyCheckdata[i].ContentId, (uint)readyCheckdata[i].ContentId );
+            ImGui.Text( $"ID: {readyCheckdata[i].ContentId:X16}, State: {readyCheckdata[i].Status}, HUD Indices: [{hudIndices?.GroupIndex}][{hudIndices?.PartyMemberIndex}]" );
+        }
 
         ImGui.NextColumn();
 
@@ -145,7 +147,7 @@ public class DebugWindow : Window, IDisposable
                 if ((nint)pGroupMember != nint.Zero)
                 {
                     var name = pGroupMember->NameString;
-                    ImGui.Text($"Group: {pGroupMember->GroupIndex}, OID: {pGroupMember->EntityId:X8}, CID: {pGroupMember->ContentId:X16}, Name: {name}");
+                    ImGui.Text($"Group: [{pGroupMember->GroupIndex}][{pGroupMember->MemberIndex}], OID: {pGroupMember->EntityId:X8}, CID: {pGroupMember->ContentId:X16}, Name: {name}");
                 }
             }
         }

--- a/ReadyCheckHelper/Windows/PartyListOverlay.cs
+++ b/ReadyCheckHelper/Windows/PartyListOverlay.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Interface.Utility;
@@ -141,6 +141,11 @@ public class PartyListOverlay : Window, IDisposable
 
         var partyMember = pPartyList->PartyMembers[index];
         var pPartyMemberNode = partyMember.PartyMemberComponent->OwnerNode;
+
+        // Prevent icons showing for members that have left in the case that we are the only remaining player in an instance that was joined as a cross-world party.
+        if (pPartyMemberNode is null || !pPartyMemberNode->IsVisible())
+            return;
+
         var pIconNode = partyMember.ClassJobIcon;
         var partyAlign = pPartyList->PartyListAtkResNode->Y;
 
@@ -169,6 +174,11 @@ public class PartyListOverlay : Window, IDisposable
         var allianceMember = pAllianceList->AllianceMembers[index];
         var allianceMemberNode = allianceMember.ComponentBase->OwnerNode;
         var pIconNode = allianceMember.ComponentBase->GetImageNodeById(9)->GetAsAtkImageNode();
+
+        // Prevent icons showing for members that have left in the case that we are the only remaining player in an instance that
+        // was joined as a cross-world alliance.  The caveat here is that someone that has disconnected will also not get an icon.
+        if (allianceMember.ClassJobImageNode is null || !allianceMember.ClassJobImageNode->IsVisible())
+            return;
 
         var iconOffset = (new Vector2(0, 0) + Plugin.Configuration.AllianceListIconOffset) * pAllianceList->Scale;
         var iconSize = new Vector2(pIconNode->Width / 3.0f, pIconNode->Height / 3.0f) * Plugin.Configuration.AllianceListIconScale * pAllianceList->Scale;

--- a/ReadyCheckHelper/Windows/PartyListOverlay.cs
+++ b/ReadyCheckHelper/Windows/PartyListOverlay.cs
@@ -86,8 +86,14 @@ public class PartyListOverlay : Window, IDisposable
             if ((nint)pCrossWorldAllianceList != nint.Zero && pCrossWorldAllianceList->IsVisible)
             {
                 for (var j = 1; j < 6; ++j)
-                for (var i = 0; i < 8; ++i)
-                    DrawOnCrossWorldAllianceList(j, i, ReadyCheckStatus.Ready, pCrossWorldAllianceList, drawList);
+                {
+                    for (var i = 0; i < 8; ++i)
+                    {
+                        //  Use recognizable patterns for each party index for easier debugging.
+                        var readyVal = i % ( j + 1 ) == 0 ? ReadyCheckStatus.Ready : ReadyCheckStatus.NotReady;
+                        DrawOnCrossWorldAllianceList( j, i, readyVal, pCrossWorldAllianceList, drawList );
+                    }
+                }
             }
         }
         else
@@ -99,26 +105,26 @@ public class PartyListOverlay : Window, IDisposable
                 if (indices == null)
                     continue;
 
-                switch (indices.Value.GroupNumber)
+                switch (indices.Value.GroupIndex)
                 {
                     case 0:
                         DrawOnPartyList(indices.Value.PartyMemberIndex, result.ReadyState, pPartyList, drawList);
                         break;
                     case 1:
                         if (indices.Value.CrossWorld)
-                            DrawOnCrossWorldAllianceList(indices.Value.GroupNumber, indices.Value.PartyMemberIndex, result.ReadyState, pCrossWorldAllianceList, drawList);
+                            DrawOnCrossWorldAllianceList(indices.Value.GroupIndex, indices.Value.PartyMemberIndex, result.ReadyState, pCrossWorldAllianceList, drawList);
                         else
                             DrawOnAllianceList(indices.Value.PartyMemberIndex, result.ReadyState, pAlliance1List, drawList);
                         break;
                     case 2:
                         if (indices.Value.CrossWorld)
-                            DrawOnCrossWorldAllianceList(indices.Value.GroupNumber, indices.Value.PartyMemberIndex, result.ReadyState, pCrossWorldAllianceList, drawList);
+                            DrawOnCrossWorldAllianceList(indices.Value.GroupIndex, indices.Value.PartyMemberIndex, result.ReadyState, pCrossWorldAllianceList, drawList);
                         else
                             DrawOnAllianceList(indices.Value.PartyMemberIndex, result.ReadyState, pAlliance2List, drawList);
                         break;
                     default:
                         if (indices.Value.CrossWorld)
-                            DrawOnCrossWorldAllianceList(indices.Value.GroupNumber, indices.Value.PartyMemberIndex, result.ReadyState, pCrossWorldAllianceList, drawList);
+                            DrawOnCrossWorldAllianceList(indices.Value.GroupIndex, indices.Value.PartyMemberIndex, result.ReadyState, pCrossWorldAllianceList, drawList);
                         break;
                 }
             }
@@ -189,6 +195,7 @@ public class PartyListOverlay : Window, IDisposable
             return;
 
         var alliance = pAllianceList->Alliances[allianceIndex-1]; // Group 1 is not in the span, so we need to subtract 1 group from this
+        if( alliance.ComponentBase is null ) return;
         var allianceNode = alliance.ComponentBase->OwnerNode;
         var allianceMember = alliance.Members[partyMemberIndex];
         var allianceMemberNode = allianceMember.AtkComponentBase->OwnerNode;


### PR DESCRIPTION
- Fix cross-world alliance icons being out of order for groups before the player's.
- Expose settings for cross-world alliance icon scale/offset in config window.
- Prevent cross-world party/alliance information being drawn while in a regular instance party/alliance and being the only player in your party.
- Fix solution configurations.
- Add a bit more debug information.  I can remove this if you don't want it, but it just made it easier to check stuff.

Opening as a draft until I can find an alliance in which I can test.